### PR TITLE
FIX: AutoSpeed 1.1 now requests correct transcript

### DIFF
--- a/Google/YoutubeAutoSpeed.user.js
+++ b/Google/YoutubeAutoSpeed.user.js
@@ -107,7 +107,6 @@ function run() {
     .then(data => {
 
         const countWords = text => text.split(" ").length
-        const getSegmentText = segment => segment.transcriptSegmentRenderer.snippet?.runs[0].text || segment.transcriptSegmentRenderer.snippet.simpleText
         const transcriptSegments = data.actions[0].updateEngagementPanelAction.content.transcriptRenderer.content.transcriptSearchPanelRenderer.body.transcriptSegmentListRenderer.initialSegments
         // console.log(transcriptSegments)
         if (data.actions.length != 1) {

--- a/Google/YoutubeAutoSpeed.user.js
+++ b/Google/YoutubeAutoSpeed.user.js
@@ -2,24 +2,25 @@
 // @name         YouTube Auto Speed
 // @namespace    https://github.com/mkazin/OhMonkey
 // @author       Michael Kazin
-// @version      1.0
+// @version      1.1
 // @description  Automatically adjusts playback speed by analyzing the video's transcript
 // @license      BSD-3-Clause
 // @match        https://www.youtube.com/watch?v=*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=youtube.com
 // @run-at       document-idle
+// @grant        GM_setValue
+// @grant        GM_getValue
 // ==/UserScript==
 
 const WPM_TABLE = [
-    { wpm_max: 350 , speed: 0.25 },
-    { wpm_max: 300 , speed: 0.5 },
-    { wpm_max: 250 , speed: 0.75 },
-    { wpm_max: 190 , speed: 1.0 },
-    { wpm_max: 140 , speed: 1.25 },
-    { wpm_max: 120 , speed: 1.50 },
+    { wpm_max: 300 , speed: 0.25 },
+    { wpm_max: 250 , speed: 0.5 },
+    { wpm_max: 200 , speed: 0.75 },
+    { wpm_max: 160 , speed: 1.0 },
+    { wpm_max: 130 , speed: 1.25 },
+    { wpm_max: 115 , speed: 1.50 },
     { wpm_max: 110 , speed: 1.75 },
     { wpm_max: 100 , speed: 2.0 },
-
 ]
 
 const MUSIC_TERMS = [
@@ -39,11 +40,15 @@ function wpmToSpeed(wpm) {
     return 1.0
 }
 
+// Using common terms used to label music content, tries to identify videos
+// which should not have their speed adjusted
+// Note: unfortunately the presense of music metadata isn't good enough to indicate that
+// the content *is* music, rather than only *has* music.
 function isMusic() {
     const title = document.title.toLocaleLowerCase()
-    const description = document.querySelector("div#description ytd-text-inline-expander#description-inline-expander")?.innerText.toLocaleLowerCase()
+    const description = document.querySelector("div#description ytd-text-inline-expander#description-inline-expander")?.innerText.toLocaleLowerCase() || ""
     return MUSIC_TERMS.some(
-        (term) => title.includes(term) || description.includes(term)
+        (term) => (title + description).includes(term)
     )
 }
 
@@ -53,11 +58,18 @@ function setSpeed(speed) {
     console.log(`${GM_info.script.name}: Speed set to ${speed}`)
 }
 
-function buildBody() {
+// Builds the 'params' attribute of the body request, which encodes the
+// video identifier YouTube's transcript API actually uses as its parameter
+function buildParams(videoId) {
+    return btoa(`\n\x0b${videoId}\x12\x12CgNhc3ISAmVuGgA%3D\x18\x01*3engagement-panel-searchable-transcript-search-panel0\x008\x01@\x01`)
+}
+// Builds the body for transcript requests
+function buildBody(context) {
+    const videoId = context.client.originalUrl.split('=')[1].replace("&t", "")
     return {
-       "context": yt.config_.INNERTUBE_CONTEXT,
+       "context": context,
        // This field is required. It's a Base64-encoded composite of several values. My initial effort only partially decoded it."
-       "params": "CgttY2dDLWt1UEV1bxISQ2dOaGMzSVNBbVZ1R2dBJTNEGAEqM2VuZ2FnZW1lbnQtcGFuZWwtc2VhcmNoYWJsZS10cmFuc2NyaXB0LXNlYXJjaC1wYW5lbDABOAFAAQ%3D%3D"
+       "params": buildParams(videoId)
     }
 }
 
@@ -65,13 +77,11 @@ function run() {
     'use strict';
     // console.log(`${GM_info.script.name} started`)
 
-
     if (isMusic()) {
         console.info(`${GM_info.script.name}: detected music. Aborting.`)
         return
     }
 
-    const URL_PREFIX = "https://www.youtube.com/watch?v="
     fetch(`https://www.youtube.com/youtubei/v1/get_transcript?key=${ytcfg.data_.INNERTUBE_API_KEY}&prettyPrint=false`, {
         "headers": {
             "accept": "*/*",
@@ -89,7 +99,7 @@ function run() {
         },
         "referrer": `${window.location.href}`,
         "referrerPolicy": "origin-when-cross-origin",
-        "body": JSON.stringify(buildBody()),
+        "body": JSON.stringify(buildBody(yt.config_.INNERTUBE_CONTEXT)),
         "method": "POST",
         "mode": "cors",
         "credentials": "include"
@@ -98,21 +108,52 @@ function run() {
     .then(data => {
 
         const countWords = text => text.split(" ").length
+        const getSegmentText = segment => segment.transcriptSegmentRenderer.snippet?.runs[0].text || segment.transcriptSegmentRenderer.snippet.simpleText
         const transcriptSegments = data.actions[0].updateEngagementPanelAction.content.transcriptRenderer.content.transcriptSearchPanelRenderer.body.transcriptSegmentListRenderer.initialSegments
+        // console.log(transcriptSegments)
         if (data.actions.length != 1) {
             // What's going on with the actions array? Should I be iterating over it too?
             console.warn(`${GM_info.script.name}: data.actions is longer than 1 => ${data.actions.length}`)
             // debugger
         }
+
+        // let wpmbuckets = {}
+        // console.log(`${GM_info.script.name}: transcriptSegments length = ${transcriptSegments.length}`)
         const transcriptTotals = Array.from(transcriptSegments).reduce( (acc, segment ) => {
-            acc.words += countWords(segment.transcriptSegmentRenderer.snippet.runs[0].text)
-            acc.ms += segment.transcriptSegmentRenderer.endMs - segment.transcriptSegmentRenderer.startMs
+            // YT Transcript contains multiple ways of encoding text:
+            const renderer = segment.transcriptSegmentRenderer || segment.transcriptSectionHeaderRenderer
+            const text = renderer.snippet?.simpleText || renderer.snippet?.runs[0].text
+            let wordCount = countWords(text)
+            // console.log(`wordcount: ${wordCount}`)
+            acc.words += wordCount
+            acc.ms += renderer.endMs - renderer.startMs;
+            // console.log(`${GM_info.script.name}: updated acc:`)
+            // console.log(acc)
+
+
+
+
+            // if (! wpmbuckets.hasOwnProperty(''+wordCount)) {
+            //     wpmbuckets[''+wordCount] = []
+            // }
+            // let sec = ((segment.transcriptSegmentRenderer.endMs - segment.transcriptSegmentRenderer.startMs)/1000.0).toFixed(2)
+
+            // wpmbuckets[''+wordCount] = (wpmbuckets[''+wordCount] || []).concat([sec])
+
+            // wpmbuckets[''+wordCount].push(parseFloat(sec).toPrecision(3))
+
+            // console.log(`${GM_info.script.name}: returning acc = ${acc}`)
             return acc
         }, { "words": 0, "ms": 0} )
 
         let wpm = transcriptTotals.words / (transcriptTotals.ms/60000.0)
         console.log(`${GM_info.script.name}: Total words: ${transcriptTotals.words} ; Total time: ${transcriptTotals.ms} ms ; wpm: ${wpm}`)
         setSpeed(wpmToSpeed(wpm))
+
+        let speedHistory = GM_getValue('SpeedHistory', [])
+        speedHistory.push({video: window.location.href.split("=")[1], words: transcriptTotals.words, time: `${(transcriptTotals.ms/1000).toFixed(2)} sec`, wpm: wpm.toFixed(2)})
+        GM_setValue('SpeedHistory', speedHistory)
+        console.log(speedHistory)
     })
 
     console.log(`${GM_info.script.name}: Transcript request sent`)

--- a/Google/YoutubeAutoSpeed.user.js
+++ b/Google/YoutubeAutoSpeed.user.js
@@ -8,8 +8,7 @@
 // @match        https://www.youtube.com/watch?v=*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=youtube.com
 // @run-at       document-idle
-// @grant        GM_setValue
-// @grant        GM_getValue
+// @grant        none
 // ==/UserScript==
 
 const WPM_TABLE = [
@@ -117,32 +116,13 @@ function run() {
             // debugger
         }
 
-        // let wpmbuckets = {}
-        // console.log(`${GM_info.script.name}: transcriptSegments length = ${transcriptSegments.length}`)
         const transcriptTotals = Array.from(transcriptSegments).reduce( (acc, segment ) => {
             // YT Transcript contains multiple ways of encoding text:
             const renderer = segment.transcriptSegmentRenderer || segment.transcriptSectionHeaderRenderer
             const text = renderer.snippet?.simpleText || renderer.snippet?.runs[0].text
             let wordCount = countWords(text)
-            // console.log(`wordcount: ${wordCount}`)
             acc.words += wordCount
             acc.ms += renderer.endMs - renderer.startMs;
-            // console.log(`${GM_info.script.name}: updated acc:`)
-            // console.log(acc)
-
-
-
-
-            // if (! wpmbuckets.hasOwnProperty(''+wordCount)) {
-            //     wpmbuckets[''+wordCount] = []
-            // }
-            // let sec = ((segment.transcriptSegmentRenderer.endMs - segment.transcriptSegmentRenderer.startMs)/1000.0).toFixed(2)
-
-            // wpmbuckets[''+wordCount] = (wpmbuckets[''+wordCount] || []).concat([sec])
-
-            // wpmbuckets[''+wordCount].push(parseFloat(sec).toPrecision(3))
-
-            // console.log(`${GM_info.script.name}: returning acc = ${acc}`)
             return acc
         }, { "words": 0, "ms": 0} )
 
@@ -150,10 +130,6 @@ function run() {
         console.log(`${GM_info.script.name}: Total words: ${transcriptTotals.words} ; Total time: ${transcriptTotals.ms} ms ; wpm: ${wpm}`)
         setSpeed(wpmToSpeed(wpm))
 
-        let speedHistory = GM_getValue('SpeedHistory', [])
-        speedHistory.push({video: window.location.href.split("=")[1], words: transcriptTotals.words, time: `${(transcriptTotals.ms/1000).toFixed(2)} sec`, wpm: wpm.toFixed(2)})
-        GM_setValue('SpeedHistory', speedHistory)
-        console.log(speedHistory)
     })
 
     console.log(`${GM_info.script.name}: Transcript request sent`)


### PR DESCRIPTION
The video id used to request the transcript is apparently encoded in the request body. It's handled correctly now. Previously AutoSpeed was requesting a transcript for the same video no matter what was being watched.

In addition, this updates the transcript parsing code to handle "section header" segments.
Perhaps these shouldn't be counted, but I assume they're insignificant when aggregated.